### PR TITLE
allow more flexible template for limit

### DIFF
--- a/Resources/public/js/EMCTable.js
+++ b/Resources/public/js/EMCTable.js
@@ -88,7 +88,7 @@ EMCTable.prototype.init = function() {
         that.find(1);
     });
 
-    this.$dom.on('change', '> tfoot > tr > td > select', function(event) {
+    this.$dom.on('change', '> tfoot > tr > td select.limit', function(event) {
         that.limit = $(this).val();
         that.find(1);
     });

--- a/Resources/views/template.html.twig
+++ b/Resources/views/template.html.twig
@@ -169,7 +169,7 @@
 
 {% block limit_select %}
     {% if total > limit %}
-        <select id="{{ id }}_limit" class="selectpicker btn-xs" data-width="70px">
+        <select id="{{ id }}_limit" class="selectpicker btn-xs limit" data-width="70px">
             <option value="10">10</option>
             <option value="20">20</option>
             <option value="50">50</option>


### PR DESCRIPTION
I needed to overwrite your base template to allow select2 filter boxes i got some problems with the positioning, and needed a surrounding div.
After that change the onChange trigger not longer works as it is very restrictive where it searches for the select element.

this pull request tries to relax this a little.

Example of my usecase:

```
{% extends 'EMCTableBundle::template.html.twig' %}

{% block tfoot %}
    <tr>
        <td colspan="{{ thead|length + (allow_select ? 1 : 0) }}">
            {{ block('pages') }}
            <div class="pull-right">{{ block('limit_select') }}</div>
        </td>
    </tr>
{% endblock %}

{% block limit_select %}
    {% if total > limit %}
        <select id="{{ id }}_limit" class="select2 btn-xs limit" data-width="70px">
            <option value="10">10</option>
            <option value="20">20</option>
            <option value="50">50</option>
            <option value="100">100</option>
            <option value="0">{{ 'All'|trans({}, 'EMCTableBundle') }}</option>
        </select>
    {% endif %}
{% endblock %}
```
