### PR TITLE
fixes failing pagination when using groupBy

### DIFF
--- a/Provider/DataProvider.php
+++ b/Provider/DataProvider.php
@@ -70,7 +70,7 @@ class DataProvider implements DataProviderInterface {
      */
     private function getQueryRows(QueryBuilder $queryBuilder, QueryConfigInterface $queryConfig, array &$mapping) {
         $queryBuilder->resetDQLPart('select');
-        
+
         $limit = $queryConfig->getLimit();
         $page = $queryConfig->getPage();
         $select = $queryConfig->getSelect();

--- a/Provider/DataProvider.php
+++ b/Provider/DataProvider.php
@@ -70,8 +70,7 @@ class DataProvider implements DataProviderInterface {
      */
     private function getQueryRows(QueryBuilder $queryBuilder, QueryConfigInterface $queryConfig, array &$mapping) {
         $queryBuilder->resetDQLPart('select');
-
-
+        
         $limit = $queryConfig->getLimit();
         $page = $queryConfig->getPage();
         $select = $queryConfig->getSelect();

--- a/Provider/DataProvider.php
+++ b/Provider/DataProvider.php
@@ -71,6 +71,7 @@ class DataProvider implements DataProviderInterface {
     private function getQueryRows(QueryBuilder $queryBuilder, QueryConfigInterface $queryConfig, array &$mapping) {
         $queryBuilder->resetDQLPart('select');
 
+
         $limit = $queryConfig->getLimit();
         $page = $queryConfig->getPage();
         $select = $queryConfig->getSelect();
@@ -109,6 +110,7 @@ class DataProvider implements DataProviderInterface {
     private function getQueryCount(QueryBuilder $queryBuilder, QueryConfigInterface $queryConfig) {
         return $queryBuilder->resetDQLPart('select')
                         ->resetDQLPart('orderBy')
+                        ->resetDQLPart('groupBy')
                         ->select('count(distinct ' . $queryBuilder->getRootAlias() . '.id)')
                         ->setMaxResults(1)
                         ->setFirstResult(0)


### PR DESCRIPTION
needs testing with dffierent usecases.

my use case was:

```
    public function buildTable(TableBuilderInterface $builder, array $options)
    {
        // [...]
        $builder->add('fields', 'text', array(
            'params' => array('GROUP_CONCAT(f.name SEPARATOR \', \')'),
            'title'  => 'Options',
            'allow_sort' => true,
            'allow_filter' => true,
        ))
        // [..]
    }

    public function getQueryBuilder(ObjectManager $entityManager, array $params)
    {
        $qb = $entityManager
            ->getRepository('Model:CustomField')
            ->createQueryBuilder('c')
            ->leftJoin('c.fields', 'f')
            ->leftJoin('c.parent', 'p')
            ->where('p is null')
            ->groupBy('c.id');

        return $qb;
    }
```
